### PR TITLE
Allow users to reset password

### DIFF
--- a/cmd/web/assets/js/confirmPassword.js
+++ b/cmd/web/assets/js/confirmPassword.js
@@ -1,0 +1,13 @@
+function confirmPassword() {
+    const password = document.getElementById("password").value;
+    const confirm = document.getElementById("confirm_password").value;
+    const errorMessage = document.getElementById("password-error");
+
+    if (password != confirm) {
+        errorMessage.classList.remove("hidden"); // Show the error message
+        document.getElementById("confirm_password").focus(); // Focus the confirm password field
+        return false
+    }
+    errorMessage.classList.add("hidden"); // Hide the error message
+    return true
+}

--- a/cmd/web/create_new_password.templ
+++ b/cmd/web/create_new_password.templ
@@ -1,0 +1,56 @@
+package web
+
+templ CreateNewPasswordPage() {
+	@Base() {
+		<div id="hello-container">
+			@CreateNewPasswordScreen()
+		</div>
+	}
+}
+
+templ CreateNewPasswordScreen() {
+<div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+  <img class="h-40 w-auto max-w-full max-h-full object-contain" src="/assets/images/ordindia.png" alt=""/>
+    <h2 class="mt-6 text-center text-xl font-bold leading-9 tracking-tight text-gray-900">Change Password</h2>
+  </div>
+
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
+    <div class="bg-white px-6 py-12 shadow sm:rounded-lg sm:px-12">
+      <form class="space-y-6" action="/create_new_password" method="POST" onsubmit="return confirmPassword()">
+
+        <div>
+          <label for="email_id" class="block text-sm font-medium leading-6 text-gray-900">Enter Email ID</label>
+          <div class="mt-2">
+            <input id="email_id" name="email_id" type="email" autocomplete="email" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+          </div>
+        </div>
+
+        <div>
+          <label for="password" class="block text-sm font-medium leading-6 text-gray-900">New Password</label>
+          <div class="mt-2">
+            <input id="password" name="password" type="password" autocomplete="password" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+          </div>
+        </div>
+
+        <div>
+          <label for="confirm_password" class="block text-sm font-medium leading-6 text-gray-900">Re-enter Password</label>
+          <div class="mt-2">
+            <input id="confirm_password" type="password" autocomplete="password" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
+          </div>
+        </div>
+
+        <p id="password-error" class="text-sm text-red-600 hidden">Passwords do not match</p>
+        <div>
+            <button type="submit" class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                Reset Password
+            </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script src="assets/js/confirmPassword.js"></script>
+
+}

--- a/cmd/web/forgot_password.templ
+++ b/cmd/web/forgot_password.templ
@@ -1,14 +1,14 @@
 package web
 
-templ LoginPage() {
+templ ForgotPasswordPage() {
 	@Base() {
 		<div id="hello-container">
-			@LoginScreen()
+			@ForgotPasswordScreen()
 		</div>
 	}
 }
 
-templ LoginScreen() {
+templ ForgotPasswordScreen() {
 <!--
   This example requires some changes to your config:
   
@@ -34,12 +34,17 @@ templ LoginScreen() {
 <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
   <img class="h-40 w-auto max-w-full max-h-full object-contain" src="/assets/images/ordindia.png" alt=""/>
-    <h2 class="mt-6 text-center text-xl font-bold leading-9 tracking-tight text-gray-900">Log in to your account</h2>
+    <h2 class="mt-6 text-center text-xl font-bold leading-9 tracking-tight text-gray-900">Trouble with logging in?</h2>
   </div>
 
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
     <div class="bg-white px-6 py-12 shadow sm:rounded-lg sm:px-12">
-      <form class="space-y-6" action="/patient_login" method="POST">
+      <form class="space-y-6" action="/forgot_password_submit" method="POST">
+        <!-- Additional Heading -->
+        <p class="text-center text-sm text-gray-700">
+          Enter your email address and we'll send you a link to get back into your account.
+        </p>
+
         <div>
           <label for="email_id" class="block text-sm font-medium leading-6 text-gray-900">Email address</label>
           <div class="mt-2">
@@ -48,37 +53,13 @@ templ LoginScreen() {
         </div>
 
         <div>
-          <label for="password" class="block text-sm font-medium leading-6 text-gray-900">Password</label>
-          <div class="mt-2">
-            <input id="password" name="password" type="password" autocomplete="current-password" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-          </div>
-        </div>
-
-        <div class="flex items-center justify-between">
-          <div class="flex items-center">
-            <input id="remember-me" name="remember-me" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600">
-            <label for="remember-me" class="ml-3 block text-sm leading-6 text-gray-900">Remember me</label>
-          </div>
-
-          <div class="text-sm leading-6">
-            <a href="/forgot_password" class="font-semibold text-indigo-600 hover:text-indigo-500">Forgot password?</a>
-          </div>
-        </div>
-
-        <div>
-          <a href="/patient_submit">
             <button type="submit" class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-              Log in
+                Send Login Link
             </button>
-          </a>
         </div>
       </form>
     </div>
 
-    <p class="mt-10 text-center text-sm text-gray-500">
-      Not a member?
-      <a href="/signup" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Join our platform</a>
-    </p>
   </div>
 </div>
 }

--- a/cmd/web/patient_signup_form.templ
+++ b/cmd/web/patient_signup_form.templ
@@ -30,7 +30,7 @@ templ PatientSignupScreen() {
 
   <div class="space-y-10 divide-y divide-gray-900/10">
     <div class="mt-8 space-y-10 divide-y divide-gray-900/10">
-      <form action="/patient_submit" method="POST">
+      <form action="/patient_submit" method="POST" onsubmit="return confirmPassword()">
         <div class="grid grid-cols-1 gap-x-8 gap-y-8 pt-10 md:grid-cols-3">
           <div class="px-4 sm:px-0">
             <h2 class="text-base font-semibold leading-7 text-gray-900">Personal Information</h2>
@@ -125,6 +125,17 @@ templ PatientSignupScreen() {
                   </div>
                   <p class="mt-2 text-sm text-gray-500">Your password must be at least 8 characters long.</p>
                 </div>
+
+                <div class="sm:col-span-4 mt-4">
+                  <label for="confirm_password" class="block text-sm font-medium leading-6 text-gray-900">
+                    Re-enter Password <span class="text-red-600">*</span>
+                  </label>
+                  <div class="mt-2">
+                    <input id="confirm_password" type="password" required class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" placeholder="Enter your password again">
+                  </div>
+                </div>
+
+                <p id="password-error" class="text-sm text-red-600 hidden">Passwords do not match</p>
 
                 <div class="sm:col-span-4">
                   <label for="country" class="block text-sm font-medium leading-6 text-gray-900">
@@ -344,4 +355,7 @@ templ PatientSignupScreen() {
     </div>
   </div>
 </div>
+
+<script src="assets/js/confirmPassword.js"></script>
+
 }

--- a/cmd/web/submit_page.templ
+++ b/cmd/web/submit_page.templ
@@ -1,14 +1,17 @@
 package web
 
-templ PatientSubmitPage() {
+import "ORDI/internal/messages"
+
+
+templ SubmitPage(message messages.SubmitMessage) {
 	@Base() {
 		<div id="hello-container">
-			@PatientSubmitScreen()
+			@SubmitScreen(message)
 		</div>
 	}
 }
 
-templ PatientSubmitScreen() {
+templ SubmitScreen(message messages.SubmitMessage) {
     <div class="rounded-md bg-green-50 p-4">
         <div class="flex">
             <div class="flex-shrink-0">
@@ -17,8 +20,8 @@ templ PatientSubmitScreen() {
                 </svg>
             </div>
             <div class="ml-3">
-                <p class="text-sm font-medium text-green-800">Successfully uploaded</p>
-                <p class="text-sm font-medium text-green-800 mt-1">A verification email has been sent to your email address. Please check your inbox to verify your account.</p>
+                <p class="text-sm font-medium text-green-800">{ message.Title }</p>
+                <p class="text-sm font-medium text-green-800 mt-1">{ message.Message }</p>
             </div>
             <div class="ml-auto pl-3">
                 <div class="-mx-1.5 -my-1.5">

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -24,4 +24,7 @@ type Database interface {
 
 	// FindByField retrieves the first record with field and provided value
 	FindByField(ctx context.Context, entity interface{}, field string, value interface{}) error
+
+	// AutoMigrate migrates database schema to match the struct definitions
+	AutoMigrate(ctx context.Context, entity interface{}) error
 }

--- a/internal/database/mysql/client.go
+++ b/internal/database/mysql/client.go
@@ -122,3 +122,10 @@ func (s *mysqlService) FindByField(ctx context.Context, entity interface{}, fiel
 	}
 	return nil
 }
+
+func (s *mysqlService) AutoMigrate(ctx context.Context, entity interface{}) error {
+	if err := s.db.WithContext(ctx).AutoMigrate(entity); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/handlers/patient/login.go
+++ b/internal/handlers/patient/login.go
@@ -12,7 +12,7 @@ func (s *patientHandler) Login(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var loginDetails struct {
-		Email    string `schema:"email"`
+		Email    string `schema:"email_id"`
 		Password string `schema:"password"`
 	}
 
@@ -29,13 +29,13 @@ func (s *patientHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find patient from database
-	patient, err := s.patientRepository.FindByField(ctx, "email", loginDetails.Email)
+	patient, err := s.patientRepository.FindByField(ctx, "email_id", loginDetails.Email)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if patient != nil {
+	if patient == nil {
 		http.Error(w, "Invalid username or password", http.StatusUnauthorized)
 		return
 	}

--- a/internal/handlers/patient/patient_handler.go
+++ b/internal/handlers/patient/patient_handler.go
@@ -3,6 +3,7 @@ package patient
 import (
 	"ORDI/internal/cache"
 	"ORDI/internal/email"
+	"ORDI/internal/models"
 	"ORDI/internal/repositories"
 	"net/http"
 )
@@ -14,13 +15,13 @@ type PatientHandlerInterface interface {
 }
 
 type patientHandler struct {
-	patientRepository repositories.Patient
+	patientRepository repositories.Repository[models.PatientInfo]
 	cache             cache.Cache
 	email             email.Email
 }
 
 type PatientHandlerConfig struct {
-	PatientRepo repositories.Patient
+	PatientRepo repositories.Repository[models.PatientInfo]
 	Cache       cache.Cache
 	Email       email.Email
 }

--- a/internal/handlers/verification/create_new_password.go
+++ b/internal/handlers/verification/create_new_password.go
@@ -1,0 +1,65 @@
+package verification
+
+import (
+	"ORDI/cmd/web"
+	"net/http"
+
+	"github.com/a-h/templ"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func (s *verificationHandler) CreateNewPassword(w http.ResponseWriter, r *http.Request) {
+	// Accept password
+	// Update password
+	// Take to login page
+
+	ctx := r.Context()
+
+	var createPasswordDetails struct {
+		Email    string `schema:"email_id"`
+		Password string `schema:"password"`
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = decoder.Decode(&createPasswordDetails, r.PostForm)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Find patient from database
+	patient, err := s.patientRepository.FindByField(ctx, "email_id", createPasswordDetails.Email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if patient == nil {
+		http.Error(w, "This user does not exist", http.StatusUnauthorized)
+		return
+	}
+
+	// Update password
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(createPasswordDetails.Password), bcrypt.DefaultCost)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	patient.Password = string(hashedPassword)
+
+	// Save updated details
+	err = s.patientRepository.Save(ctx, patient)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Take to login
+	templ.Handler(web.LoginPage()).ServeHTTP(w, r)
+
+}

--- a/internal/handlers/verification/forgot_password.go
+++ b/internal/handlers/verification/forgot_password.go
@@ -1,0 +1,75 @@
+package verification
+
+import (
+	"ORDI/cmd/web"
+	"ORDI/internal/messages"
+	"ORDI/internal/utils"
+	"net/http"
+	"time"
+
+	"github.com/a-h/templ"
+)
+
+func (s *verificationHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
+	// Receive an email from form
+	// Verify that this email is an existing user
+	// Generate token
+	// Send email
+	ctx := r.Context()
+
+	var forgotPasswordDetails struct {
+		Email string `schema:"email_id"`
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	err = decoder.Decode(&forgotPasswordDetails, r.PostForm)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Find patient from database
+	patient, err := s.patientRepository.FindByField(ctx, "email_id", forgotPasswordDetails.Email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if patient == nil {
+		http.Error(w, "This user does not exist", http.StatusUnauthorized)
+		return
+	}
+
+	// Generate token
+	token, err := utils.GenerateVerificationtoken()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Store token in cache
+	err = s.cache.Set(ctx, token, patient.Email, 15*time.Minute)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Generate html body for verification mail
+	htmlBody := utils.GenerateVerificationHTML(ctx, token, "verify_existing_patient", "You told us you forgot your password.")
+	err = s.email.SendEmail(patient.Email, "Reset your Password", htmlBody, nil, "", "text/html")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Display the message that email has been sent
+	templ.Handler(web.SubmitPage(messages.SubmitMessage{
+		Title:   "Forgot Password Request sent",
+		Message: "A verification email has been sent to your email address. Please click on the link provided to proceed ahead.",
+	})).ServeHTTP(w, r)
+}

--- a/internal/messages/submit_message.go
+++ b/internal/messages/submit_message.go
@@ -1,0 +1,6 @@
+package messages
+
+type SubmitMessage struct {
+	Title   string
+	Message string
+}

--- a/internal/repositories/patient.go
+++ b/internal/repositories/patient.go
@@ -9,21 +9,16 @@ import (
 	"gorm.io/gorm"
 )
 
-type Patient interface {
-	Save(ctx context.Context, patient *models.PatientInfo) error
-
-	FindByID(ctx context.Context, id uint) (*models.PatientInfo, error)
-
-	Delete(ctx context.Context, patient *models.PatientInfo) error
-
-	FindByField(ctx context.Context, field string, value interface{}) (*models.PatientInfo, error)
-}
-
 type patientRepository struct {
 	db database.Database
 }
 
 func NewPatientRepository(db database.Database) *patientRepository {
+	// Create patient table if it doesn't already exist
+	if err := db.AutoMigrate(context.Background(), &models.PatientInfo{}); err != nil {
+		// Panic if unable to create database
+		panic("Failed to migrate patient database: " + err.Error())
+	}
 	return &patientRepository{
 		db: db,
 	}

--- a/internal/repositories/repository.go
+++ b/internal/repositories/repository.go
@@ -1,0 +1,15 @@
+package repositories
+
+import (
+	"context"
+)
+
+type Repository[T any] interface {
+	Save(ctx context.Context, entity *T) error
+
+	FindByID(ctx context.Context, id uint) (*T, error)
+
+	Delete(ctx context.Context, entity *T) error
+
+	FindByField(ctx context.Context, field string, value interface{}) (*T, error)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -4,6 +4,7 @@ import (
 	"ORDI/cmd/web"
 	"ORDI/internal/handlers/patient"
 	"ORDI/internal/handlers/verification"
+	"ORDI/internal/models"
 	"ORDI/internal/repositories"
 	"encoding/json"
 	"log"
@@ -14,7 +15,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-func (s *Server) RegisterPatientRoutes(r *chi.Mux, patientRepository repositories.Patient) {
+func (s *Server) RegisterPatientRoutes(r *chi.Mux, patientRepository repositories.Repository[models.PatientInfo]) {
 	patientHandler := patient.NewPatientHandler(patient.PatientHandlerConfig{
 		PatientRepo: patientRepository,
 		Cache:       s.cache,
@@ -26,14 +27,19 @@ func (s *Server) RegisterPatientRoutes(r *chi.Mux, patientRepository repositorie
 	r.Post("/patient_login", patientHandler.Login)
 	r.Get("/patient_dashboard", templ.Handler(web.PatientDashboardPage()).ServeHTTP)
 	r.Get("/appointments", patientHandler.Appointment)
+	r.Get("/forgot_password", templ.Handler(web.ForgotPasswordPage()).ServeHTTP)
 }
 
-func (s *Server) RegisterVerificationRoutes(r *chi.Mux, patientRepository repositories.Patient) {
+func (s *Server) RegisterVerificationRoutes(r *chi.Mux, patientRepository repositories.Repository[models.PatientInfo]) {
 	verificationHandler := verification.NewVerificationHandler(verification.VerificationConfig{
 		PatientRepo: patientRepository,
 		Cache:       s.cache,
+		EmailID:     s.email,
 	})
-	r.Get("/verify_patient", verificationHandler.VerifyPatient)
+	r.Get("/verify_patient", verificationHandler.VerifyNewPatient)
+	r.Get("/verify_existing_patient", verificationHandler.VerifyExistingPatient)
+	r.Post("/create_new_password", verificationHandler.CreateNewPassword)
+	r.Post("/forgot_password_submit", verificationHandler.ForgotPassword)
 }
 
 func (s *Server) RegisterRoutes() http.Handler {
@@ -57,6 +63,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	s.RegisterPatientRoutes(r, patientRepository)
 
 	// Verification handler
+	s.RegisterVerificationRoutes(r, patientRepository)
 
 	return r
 }

--- a/internal/utils/verification.go
+++ b/internal/utils/verification.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+func GenerateVerificationHTML(ctx context.Context, token string, endpoint string, message string) string {
+
+	verificationURL := fmt.Sprintf("ordindia.foundation/%s?token=%s", endpoint, token)
+	htmlBody := fmt.Sprintf(`
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<title>Verify your email</title>
+		</head>
+		<body>
+			<h2>%s</h2>
+			<p>Please click the link below to verify your email address:</p>
+			<p><a href="%s" style="color: #3498db; text-decoration: none;">Verify Email</a></p>
+			<p>This link is valid for 15 minutes.</p>
+			<p>If you did not request this, you can ignore this email.</p>
+		</body>
+		</html>
+`, message, verificationURL)
+
+	return htmlBody
+}
+
+// Generate verification token
+func GenerateVerificationtoken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	// Encode the byte slice to a URL-safe base64 string
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}


### PR DESCRIPTION
Solves [Issue-5](https://github.com/Organisations-For-Rare-Disease-India/ORDI-Service/issues/5)

Following is the flow
- Users click on Forgot Password
- Users enter their email
- A verification mail is sent to their email
- On clicking the link from the mail, A page that takes in new password
- Updated password is saved to database
- User is taken to login again, and can login with the updated password.

<img width="547" alt="Screenshot 2024-11-10 at 17 13 10" src="https://github.com/user-attachments/assets/06632833-2075-4fcb-bf76-2e7d6e460082">
<img width="611" alt="Screenshot 2024-11-10 at 17 13 18" src="https://github.com/user-attachments/assets/135455e5-d390-4f2b-8960-d344587f62d1">
<img width="875" alt="Screenshot 2024-11-10 at 17 13 30" src="https://github.com/user-attachments/assets/d5585ba9-112f-48d5-b27a-d1dc22467890">
<img width="449" alt="Screenshot 2024-11-10 at 17 13 43" src="https://github.com/user-attachments/assets/7a0fc307-42b6-48f0-a0c6-eeb127644112">
<img width="609" alt="Screenshot 2024-11-10 at 17 14 02" src="https://github.com/user-attachments/assets/a7bac8b8-3374-4333-b6cf-a021b987c2db">


